### PR TITLE
Performancemetric

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "dataaccessgateway",
-  "version": "0.0.21",
+  "version": "0.0.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dataaccessgateway",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "A simple library that cache in two different levels HTTP requests",
   "repository": {
     "type": "git",

--- a/src/dataAccessGateway.ts
+++ b/src/dataAccessGateway.ts
@@ -1,7 +1,7 @@
 
 import axios, { AxiosPromise, AxiosRequestConfig, AxiosResponse } from "axios";
 import Dexie from "dexie";
-import { AjaxRequest, CacheDataWithId, CachedData, DataAction, DataResponse, DataSource, LogError, LogInfo, OnGoingAjaxRequest } from "./model";
+import { AjaxRequest, CacheDataWithId, CachedData, DataAction, DataResponse, DataSource, LogError, LogInfo, OnGoingAjaxRequest, PerformanceRequestInsight } from "./model";
 export class DataAccessIndexDbDatabase extends Dexie {
     public data!: Dexie.Table<CacheDataWithId<any>, string>; // Will be initialized later
 
@@ -56,17 +56,18 @@ export class DataAccessSingleton implements IDataAccessSingleton {
         isCacheMandatoryIfEnabled: true,
         defaultLifeSpanInSeconds: 5 * 60,
         logError: () => { /*Nothing*/ },
-        logInfo: () => { /*Nothing*/ },
+        logInfo: () => { /*Nothing*/ }
     };
     public options: DataAccessSingletonOptions = this.DefaultOptions;
-    public onGoingRequest: Map<string, OnGoingAjaxRequest> = new Map<string, OnGoingAjaxRequest>();
+    public onGoingAjaxRequest: Map<string, OnGoingAjaxRequest> = new Map<string, OnGoingAjaxRequest>();
+    public performanceInsights: Map<string, PerformanceRequestInsight> = new Map<string, PerformanceRequestInsight>();
     public cachedResponse: Map<string, string> = new Map<string, string>();
     public openIndexDb?: DataAccessIndexDbDatabase;
     public constructor(databaseName: string) {
         try {
             this.openIndexDb = new DataAccessIndexDbDatabase(databaseName);
         } catch (e) {
-            this.options.logError({ action: DataAction.System, source: DataSource.System, error: e });
+            this.logError({ action: DataAction.System, source: DataSource.System, error: e });
         }
     }
 
@@ -78,12 +79,23 @@ export class DataAccessSingleton implements IDataAccessSingleton {
         return DataAccessSingleton.instance;
     }
 
-    public logInfo(info: LogInfo): void {
-        this.options.logInfo(info);
+    public logInfo(info: Pick<LogInfo, Exclude<keyof LogInfo, "kind">>): void {
+        const requestInfo: LogInfo = { ...info, kind: "LogInfo" };
+        this.options.logInfo(requestInfo);
         if (window) {
             window.postMessage({
                 source: "dataaccessgateway-agent",
-                payload: info
+                payload: requestInfo
+            }, "*");
+        }
+    }
+    public logError(error: Pick<LogError, Exclude<keyof LogError, "kind">>): void {
+        const requestError: LogError = { ...error, kind: "LogError" };
+        this.options.logError({ ...error, kind: "LogError" });
+        if (window) {
+            window.postMessage({
+                source: "dataaccessgateway-agent",
+                payload: requestError
             }, "*");
         }
     }
@@ -96,10 +108,22 @@ export class DataAccessSingleton implements IDataAccessSingleton {
 
     public fetchWeb<T>(request: AjaxRequest): Promise<DataResponse<T>> {
         this.setDefaultRequestId(request); // Default values        
+        this.startPerformanceInsight(request.id!);
         return this.fetchAndSaveInCacheIfExpired<T>(request, DataSource.HttpRequest)
             .then((response: DataResponse<T>) => {
-                this.logInfo({ action: DataAction.Use, id: request.id!, source: DataSource.HttpRequest });
+                this.stopPerformanceInsight(this.getPerformanceInsight(request.id!));
+                this.logInfo(
+                    {
+                        action: DataAction.Use,
+                        id: request.id!,
+                        source: DataSource.HttpRequest,
+                        performanceInsight: this.setDataSize(this.getPerformanceInsight(request.id!), response.result)
+                    });
+                this.deletePerformanceInsight(request.id!);
                 return response;
+            }).catch((reason: any) => {
+                this.deletePerformanceInsight(request.id!);
+                throw reason;
             });
     }
     /**
@@ -110,28 +134,51 @@ export class DataAccessSingleton implements IDataAccessSingleton {
     public fetchFresh<T>(request: AjaxRequest): Promise<DataResponse<T>> {
         this.setDefaultRequestId(request); // Default values        
         this.setDefaultCache(request); // We enforce a minimum memory cache of few seconds
-
+        this.startPerformanceInsight(request.id!);
         return this.tryMemoryCacheFetching<T>(request)
             .then((memoryCacheValue: DataResponse<T> | undefined) => {
                 if (memoryCacheValue === undefined) {
                     return this.tryPersistentStorageFetching<T>(request)
                         .then((persistentCacheValue: DataResponse<T> | undefined) => {
                             if (persistentCacheValue !== undefined) {
-                                this.logInfo({ action: DataAction.Use, id: request.id!, source: DataSource.PersistentStorageCache });
+                                this.logInfo(
+                                    {
+                                        action: DataAction.Use,
+                                        id: request.id!,
+                                        source: DataSource.PersistentStorageCache,
+                                        performanceInsight: this.setDataSize(this.getPerformanceInsight(request.id!), persistentCacheValue.result)
+                                    });
                             }
                             return persistentCacheValue;
                         }).catch((reason: any) => {
-                            this.options.logError({ error: reason, source: DataSource.PersistentStorageCache, action: DataAction.Fetch });
+                            this.logError({ error: reason, source: DataSource.PersistentStorageCache, action: DataAction.Fetch });
                             return undefined;
                         });
                 } else {
-                    this.logInfo({ action: DataAction.Use, id: request.id!, source: DataSource.MemoryCache });
+                    this.stopPerformanceInsight(request.id!);
+                    this.logInfo(
+                        {
+                            action: DataAction.Use,
+                            id: request.id!,
+                            source: DataSource.MemoryCache,
+                            performanceInsight: this.setDataSize(this.getPerformanceInsight(request.id!), memoryCacheValue)
+                        });
+                    this.deletePerformanceInsight(request.id!);
                     return memoryCacheValue;
                 }
             }).then((memoryOrPersistentCacheValue: DataResponse<T> | undefined) => {
                 if (memoryOrPersistentCacheValue === undefined) {
+                    this.startPerformanceInsight(request.id!, DataSource.HttpRequest);
                     return this.fetchWithAjax<T>(request).then((value: AxiosResponse<T>) => {
-                        this.logInfo({ action: DataAction.Use, id: request.id!, source: DataSource.HttpRequest });
+                        this.stopPerformanceInsight(request.id!, DataSource.HttpRequest);
+                        this.logInfo(
+                            {
+                                action: DataAction.Use,
+                                id: request.id!,
+                                source: DataSource.HttpRequest,
+                                performanceInsight: this.setDataSize(this.getPerformanceInsight(request.id!), value.data)
+                            });
+                        this.deletePerformanceInsight(request.id!);
                         return Promise.resolve({
                             source: DataSource.HttpRequest,
                             result: value.data
@@ -152,17 +199,25 @@ export class DataAccessSingleton implements IDataAccessSingleton {
      * to fetch the new value. Fetch fast works better if most of the data (if not all) is stored with a persistence
      */
     public fetchFast<T>(request: AjaxRequest): Promise<DataResponse<T>> {
+        this.setDefaultRequestId(request); // Default values        
+        this.setDefaultFastCache(request); // We enforce a minimum memory cache of few seconds
+        this.startPerformanceInsight(request.id!);
+
         // If the flag is off, we skip and go directly to the Ajax
         if (!this.options.isCacheEnabled) {
             return this.fetchAndSaveInCacheIfExpired<T>(request, DataSource.HttpRequest)
                 .then((response: DataResponse<T>) => {
-                    this.logInfo({ action: DataAction.Use, id: request.id!, source: DataSource.HttpRequest });
+                    this.stopPerformanceInsight(request.id!, DataSource.HttpRequest);
+                    this.logInfo(
+                        {
+                            action: DataAction.Use,
+                            id: request.id!,
+                            source: DataSource.HttpRequest,
+                            performanceInsight: this.setDataSize(this.getPerformanceInsight(request.id!), response.result)
+                        });
                     return response;
                 });
         }
-
-        this.setDefaultRequestId(request); // Default values        
-        this.setDefaultFastCache(request); // We enforce a minimum memory cache of few seconds
 
         // Check memory cache first
         const memoryCacheEntry: CachedData<T> | undefined = this.getMemoryStoreData(request.id!);
@@ -173,7 +228,14 @@ export class DataAccessSingleton implements IDataAccessSingleton {
                     // Not in the persistent storage means we must fetch from API
                     return this.fetchAndSaveInCacheIfExpired<T>(request, DataSource.HttpRequest)
                         .then((response: DataResponse<T>) => {
-                            this.logInfo({ action: DataAction.Use, id: request.id!, source: DataSource.HttpRequest });
+                            this.stopPerformanceInsight(request.id!);
+                            this.logInfo(
+                                {
+                                    action: DataAction.Use,
+                                    id: request.id!,
+                                    source: DataSource.HttpRequest,
+                                    performanceInsight: this.setDataSize(this.getPerformanceInsight(request.id!), response.result)
+                                });
                             return response;
                         });
                 } else {
@@ -184,7 +246,14 @@ export class DataAccessSingleton implements IDataAccessSingleton {
                     }
                     this.fetchAndSaveInCacheIfExpired<T>(request, DataSource.PersistentStorageCache, persistentStorageEntry); // It's expired which mean we fetch to get fresh data HOWEVER, we will return the obsolete data to have a fast response
                     // Return the persistent storage even if expired
-                    this.logInfo({ action: DataAction.Use, id: request.id!, source: DataSource.PersistentStorageCache });
+                    this.stopPerformanceInsight(request.id!);
+                    this.logInfo(
+                        {
+                            action: DataAction.Use,
+                            id: request.id!,
+                            source: DataSource.PersistentStorageCache,
+                            performanceInsight: this.setDataSize(this.getPerformanceInsight(request.id!), persistentStorageEntry.payload)
+                        });
                     return Promise.resolve({
                         source: DataSource.PersistentStorageCache,
                         result: persistentStorageEntry.payload
@@ -193,7 +262,15 @@ export class DataAccessSingleton implements IDataAccessSingleton {
             });
         } else {
             this.fetchAndSaveInCacheIfExpired<T>(request, DataSource.MemoryCache, memoryCacheEntry); // We have something in the memory, but we might still want to fetch if expire for future requests
-            this.logInfo({ action: DataAction.Use, id: request.id!, source: DataSource.MemoryCache });
+            this.stopPerformanceInsight(request.id!, DataSource.MemoryCache);
+            this.stopPerformanceInsight(request.id!);
+            this.logInfo(
+                {
+                    action: DataAction.Use,
+                    id: request.id!,
+                    source: DataSource.MemoryCache,
+                    performanceInsight: this.setDataSize(this.getPerformanceInsight(request.id!), memoryCacheEntry.payload)
+                });
             return Promise.resolve({
                 source: DataSource.MemoryCache,
                 result: memoryCacheEntry.payload
@@ -204,9 +281,11 @@ export class DataAccessSingleton implements IDataAccessSingleton {
     public async fetchAndSaveInCacheIfExpired<T>(request: AjaxRequest, source: DataSource, cacheEntry?: CachedData<T> | undefined): Promise<DataResponse<T>> {
         if (cacheEntry === undefined || (new Date()).getTime() > new Date(cacheEntry.expirationDateTime).getTime()) {
             try {
+                this.startPerformanceInsight(request.id!, DataSource.HttpRequest);
                 const value: AxiosResponse<T> = await this.fetchWithAjax<T>(request);
+                this.setDataSize(this.stopPerformanceInsight(request.id!, DataSource.HttpRequest), value.data);
                 if (value.status >= 200 && value.status <= 399) {
-                    this.logInfo({ action: DataAction.Fetch, id: request.id!, source: DataSource.HttpRequest });
+                    this.logInfo({ action: DataAction.Fetch, id: request.id!, source: DataSource.HttpRequest, performanceInsight: this.getPerformanceInsight(request.id!) });
                     return this.saveCache(request, {
                         source: DataSource.HttpRequest,
                         result: value.data
@@ -215,7 +294,8 @@ export class DataAccessSingleton implements IDataAccessSingleton {
                     throw Error("Cannot cache request that are not in the range of 200 or in the range of 300.");
                 }
             } catch (error) {
-                this.options.logError({ error: error, source: DataSource.HttpRequest, action: DataAction.Fetch });
+                this.stopPerformanceInsight(this.getPerformanceInsight(request.id!), DataSource.HttpRequest);
+                this.logError({ error: error, source: DataSource.HttpRequest, action: DataAction.Fetch });
                 throw error;
             };
         } else {
@@ -296,7 +376,13 @@ export class DataAccessSingleton implements IDataAccessSingleton {
                 if (new Date().getTime() > (new Date(localStorageCacheEntry.expirationDateTime)).getTime()) {
                     this.deleteFromPersistentStorage(request.id!);
                 } else {
-                    this.logInfo({ action: DataAction.Use, id: request.id!, source: DataSource.PersistentStorageCache });
+                    this.logInfo(
+                        {
+                            action: DataAction.Use,
+                            id: request.id!,
+                            source: DataSource.PersistentStorageCache,
+                            performanceInsight: this.setDataSize(this.getPerformanceInsight(request.id!), localStorageCacheEntry.payload)
+                        });
                     return {
                         source: DataSource.PersistentStorageCache,
                         result: localStorageCacheEntry.payload
@@ -305,7 +391,7 @@ export class DataAccessSingleton implements IDataAccessSingleton {
             }
             return Promise.resolve(undefined);
         } catch (reason) {
-            this.options.logError({ error: reason, source: DataSource.PersistentStorageCache, action: DataAction.Fetch });
+            this.logError({ error: reason, source: DataSource.PersistentStorageCache, action: DataAction.Use });
             return undefined;
         }
     }
@@ -315,43 +401,147 @@ export class DataAccessSingleton implements IDataAccessSingleton {
     }
     public fetchWithAjax<T>(request: AjaxRequest): AxiosPromise<T> {
         // Check if already on-going request
-        const cacheOnGoingEntry: OnGoingAjaxRequest | undefined = this.onGoingRequest.get(request.id!);
+        const cacheOnGoingEntry: OnGoingAjaxRequest | undefined = this.onGoingAjaxRequest.get(request.id!);
         if (cacheOnGoingEntry === undefined) {
             // Execute Ajax call
             // Add listener to remove from onGoing once we receive a success or failure from the request
             const promiseAjaxResponse = this.ajax(request.request)
                 .then((response: AxiosResponse<T>) => {
-                    this.deleteOnGoingRequest(request.id!);
+                    this.deleteOnGoingAjaxRequest(request.id!);
                     return response;
                 }).catch((reason) => {
-                    this.deleteOnGoingRequest(request.id!);
+                    this.deleteOnGoingAjaxRequest(request.id!);
                     throw reason;
                 });
             // Add into the on-going queue
-            this.addOnGoingRequest(request.id!, request, promiseAjaxResponse);
+            this.addOnGoingAjaxRequest(request.id!, request, promiseAjaxResponse);
             return promiseAjaxResponse;
         } else {
             // Already on-going fetching, return the response promise from previous request.
-            this.logInfo({ id: request.id!, source: DataSource.HttpRequest, action: DataAction.WaitingOnGoingRequest });
+            this.logInfo({ id: request.id!, source: DataSource.HttpRequest, action: DataAction.WaitingOnGoingRequest, performanceInsight: this.getPerformanceInsight(request.id!) });
             return cacheOnGoingEntry.promise;
         }
     }
+    public getActualTimeTick(): number {
+        return window.performance.now();
+    }
+    public getPerformanceInsight(requestId: string): PerformanceRequestInsight {
+        let existing = this.performanceInsights.get(requestId);
+        if (existing === undefined) {
+            const newPerformanceInsight: PerformanceRequestInsight = {
+                fetch: {
+                    startMs: 0,
+                    stopMs: 0
+                }
+            };
+            this.performanceInsights.set(requestId, newPerformanceInsight);
+            existing = newPerformanceInsight;
+
+        }
+        return existing;
+    }
+    public startPerformanceInsight(insight: PerformanceRequestInsight, source?: DataSource): PerformanceRequestInsight;
+    public startPerformanceInsight(requestId: string, source?: DataSource): PerformanceRequestInsight;
+    public startPerformanceInsight(insightOrRequestId: PerformanceRequestInsight | string, source?: DataSource): PerformanceRequestInsight {
+        let insight: PerformanceRequestInsight;
+        if (typeof insightOrRequestId === "string") {
+            insight = this.getPerformanceInsight(insightOrRequestId);
+        } else {
+            insight = insightOrRequestId;
+        }
+        const startTime = this.getActualTimeTick();
+        const performanceMarker = { startMs: startTime };
+
+        if (source === undefined) {
+            insight.fetch = performanceMarker;
+        } else {
+            switch (source) {
+                case DataSource.HttpRequest:
+                    insight.httpRequest = performanceMarker;
+                    break;
+                case DataSource.MemoryCache:
+                    insight.memoryCache = performanceMarker;
+                    break;
+                case DataSource.PersistentStorageCache:
+                    insight.persistentStorageCache = performanceMarker;
+                    break;
+                case DataSource.System:
+                    // Nothing to do
+                    break;
+                default:
+                    this.exhaustiveCheck(source);
+            }
+        }
+        return insight;
+    }
+    public stopPerformanceInsight(insight: PerformanceRequestInsight, source?: DataSource): PerformanceRequestInsight;
+    public stopPerformanceInsight(requestId: string, source?: DataSource): PerformanceRequestInsight;
+    public stopPerformanceInsight(insightOrRequestId: PerformanceRequestInsight | string, source?: DataSource): PerformanceRequestInsight {
+        let insight: PerformanceRequestInsight;
+        if (typeof insightOrRequestId === "string") {
+            insight = this.getPerformanceInsight(insightOrRequestId);
+        } else {
+            insight = insightOrRequestId;
+        }
+        const stopTime = this.getActualTimeTick();
+        if (source === undefined) {
+            insight.fetch.stopMs = stopTime;
+        } else {
+            switch (source) {
+                case DataSource.HttpRequest:
+                    if (insight.httpRequest !== undefined) {
+                        insight.httpRequest.stopMs = stopTime;
+                    }
+                    break;
+                case DataSource.MemoryCache:
+                    if (insight.memoryCache !== undefined) {
+                        insight.memoryCache.stopMs = stopTime;
+                    }
+                    break;
+                case DataSource.PersistentStorageCache:
+                    if (insight.persistentStorageCache !== undefined) {
+                        insight.persistentStorageCache.stopMs = stopTime;
+                    }
+                    break;
+                case DataSource.System:
+                    // Nothing to do
+                    break;
+                default:
+                    this.exhaustiveCheck(source);
+            }
+        }
+        return insight;
+    }
+    public exhaustiveCheck(source: never): never {
+        throw Error("Missing source: " + source);
+    }
+
+    public deletePerformanceInsight(id: string): void {
+        this.performanceInsights.delete(id);
+    }
+
+    public setDataSize<T>(insight: PerformanceRequestInsight, data: T): PerformanceRequestInsight {
+        if (data !== undefined) {
+            insight.dataSizeInBytes = JSON.stringify(data).length;
+        }
+        return insight;
+    }
 
     public deleteFromMemoryCache(id: string): void {
-        this.logInfo({ id: id, source: DataSource.MemoryCache, action: DataAction.Delete });
+        this.logInfo({ id: id, source: DataSource.MemoryCache, action: DataAction.Delete, performanceInsight: this.getPerformanceInsight(id) });
         this.cachedResponse.delete(id);
     }
 
-    public addOnGoingRequest<T>(id: string, request: AjaxRequest, promiseAjaxResponse: Promise<AxiosResponse<T>>): void {
-        this.logInfo({ id: id, source: DataSource.HttpRequest, action: DataAction.AddFromOnGoingRequest });
-        this.onGoingRequest.set(request.id!, {
+    public addOnGoingAjaxRequest<T>(id: string, request: AjaxRequest, promiseAjaxResponse: Promise<AxiosResponse<T>>): void {
+        this.logInfo({ id: id, source: DataSource.HttpRequest, action: DataAction.AddFromOnGoingRequest, performanceInsight: this.getPerformanceInsight(id) });
+        this.onGoingAjaxRequest.set(request.id!, {
             ajaxRequest: request,
             promise: promiseAjaxResponse
         });
     }
-    public deleteOnGoingRequest(id: string): void {
-        this.logInfo({ id: id, source: DataSource.HttpRequest, action: DataAction.RemoveFromOnGoingRequest });
-        this.onGoingRequest.delete(id);
+    public deleteOnGoingAjaxRequest(id: string): void {
+        this.logInfo({ id: id, source: DataSource.HttpRequest, action: DataAction.RemoveFromOnGoingRequest, performanceInsight: this.getPerformanceInsight(id) });
+        this.onGoingAjaxRequest.delete(id);
     }
 
     public addInMemoryCache<T>(id: string, lifespanInSeconds: number, dataToAdd: T): void {
@@ -360,7 +550,7 @@ export class DataAccessSingleton implements IDataAccessSingleton {
             expirationDateTime: currentUTCDataWithLifeSpanAdded,
             payload: dataToAdd
         }));
-        this.logInfo({ id: id, source: DataSource.MemoryCache, action: DataAction.Save });
+        this.logInfo({ id: id, source: DataSource.MemoryCache, action: DataAction.Save, performanceInsight: this.getPerformanceInsight(id) });
     }
 
     public addInPersistentStore<T>(id: string, cacheData: CachedData<T>): void {
@@ -373,21 +563,23 @@ export class DataAccessSingleton implements IDataAccessSingleton {
                     return;
                 }
                 const putPromise = this.openIndexDb.data.put({ id: id, ...cacheData }).then(() => {
-                    this.logInfo({ id: id, source: DataSource.PersistentStorageCache, action: DataAction.Save });
+                    this.logInfo({ id: id, source: DataSource.PersistentStorageCache, action: DataAction.Save, performanceInsight: this.getPerformanceInsight(id) });
                 }).catch((e) => {
-                    this.options.logError({ error: e, source: DataSource.PersistentStorageCache, action: DataAction.Save });
+                    this.logError({ error: e, source: DataSource.PersistentStorageCache, action: DataAction.Save });
                 });
                 return putPromise;
             }).catch(e => {
-                this.options.logError({ error: e, source: DataSource.PersistentStorageCache, action: DataAction.Save });
+                this.logError({ error: e, source: DataSource.PersistentStorageCache, action: DataAction.Save });
             });
         } catch (reason) {
-            this.options.logError({ error: reason, source: DataSource.PersistentStorageCache, action: DataAction.Save });
+            this.logError({ error: reason, source: DataSource.PersistentStorageCache, action: DataAction.Save });
         }
     }
     public getMemoryStoreData<T>(id: string): CachedData<T> | undefined {
+        this.startPerformanceInsight(id, DataSource.MemoryCache);
         const cacheValue = this.cachedResponse.get(id);
-        this.logInfo({ action: DataAction.Fetch, id: id, source: DataSource.MemoryCache });
+        this.stopPerformanceInsight(id, DataSource.MemoryCache);
+        this.logInfo({ action: DataAction.Fetch, id: id, source: DataSource.MemoryCache, performanceInsight: this.getPerformanceInsight(id) });
         if (cacheValue === undefined) {
             return undefined;
         }
@@ -398,12 +590,14 @@ export class DataAccessSingleton implements IDataAccessSingleton {
             if (this.openIndexDb === undefined) {
                 return undefined;
             }
+            this.startPerformanceInsight(id, DataSource.PersistentStorageCache);
             const resultPromise = await this.openIndexDb.data.get(id);
-            this.logInfo({ action: DataAction.Fetch, id: id, source: DataSource.PersistentStorageCache });
+            this.stopPerformanceInsight(id, DataSource.PersistentStorageCache);
+            this.logInfo({ action: DataAction.Fetch, id: id, source: DataSource.PersistentStorageCache, performanceInsight: this.getPerformanceInsight(id) });
             return resultPromise;
         }
         catch (reason) {
-            this.options.logError({ error: reason, source: DataSource.PersistentStorageCache, action: DataAction.Fetch });
+            this.logError({ error: reason, source: DataSource.PersistentStorageCache, action: DataAction.Fetch });
             return undefined;
         }
     }
@@ -415,7 +609,7 @@ export class DataAccessSingleton implements IDataAccessSingleton {
             }
             return this.openIndexDb.data.delete(id);
         } catch (reason) {
-            this.options.logError({ error: reason, source: DataSource.PersistentStorageCache, action: DataAction.Delete });
+            this.logError({ error: reason, source: DataSource.PersistentStorageCache, action: DataAction.Delete });
         }
     }
 

--- a/src/dataAccessGateway.ts
+++ b/src/dataAccessGateway.ts
@@ -91,7 +91,7 @@ export class DataAccessSingleton implements IDataAccessSingleton {
     }
     public logError(error: Pick<LogError, Exclude<keyof LogError, "kind">>): void {
         const requestError: LogError = { ...error, kind: "LogError" };
-        this.options.logError({ ...error, kind: "LogError" });
+        this.options.logError(requestError);
         if (window) {
             window.postMessage({
                 source: "dataaccessgateway-agent",

--- a/src/model.ts
+++ b/src/model.ts
@@ -34,6 +34,18 @@ export interface OnGoingAjaxRequest {
     ajaxRequest: AjaxRequest;
     promise: Promise<any>;
 }
+
+export interface PerformanceTimeMarker {
+    startMs: number;
+    stopMs?: number;
+}
+export interface PerformanceRequestInsight {
+    fetch: PerformanceTimeMarker;
+    memoryCache?: PerformanceTimeMarker;
+    persistentStorageCache?: PerformanceTimeMarker;
+    httpRequest?: PerformanceTimeMarker;
+    dataSizeInBytes?: number;
+}
 export enum DataSource {
     HttpRequest = "HttpRequest",
     MemoryCache = "MemoryCache",
@@ -60,8 +72,11 @@ export interface LogBase {
     action: DataAction;
 }
 export interface LogError extends LogBase {
+    kind: "LogError";
     error: any;
 }
 export interface LogInfo extends LogBase {
+    kind: "LogInfo";
     id: string;
+    performanceInsight?: PerformanceRequestInsight;
 }


### PR DESCRIPTION
- All the time for specific DataAction. The additional data allows bringing more insight about the timing between fetching data from the different sources. The DataAction.Use allows at the top level (fetchFast, fetchFresh and fetchWeb) to get the overall timing with all the tentative of getting from the caches. This result in an insight that is not available elsewhere (e.g. not in Chrome Network tab).

Information about the size of the payload gives a view into how many bytes of data can be saved using the caches.